### PR TITLE
HH-73950 improve precision of logging of response time

### DIFF
--- a/client/src/main/java/ru/hh/jclient/common/HttpClientImpl.java
+++ b/client/src/main/java/ru/hh/jclient/common/HttpClientImpl.java
@@ -145,21 +145,23 @@ class HttpClientImpl extends HttpClient {
 
     @Override
     public Response onCompleted(Response response) throws Exception {
+      long millisOfResponseReceiving = requestStart.until(now(), ChronoUnit.MILLIS);
       int responseStatusCode = response.getStatusCode();
       String responseStatusText = response.getStatusText();
       mdcCopy.doInContext( () -> log.info("ASYNC_HTTP_RESPONSE: {} {} in {} ms on {} {}", responseStatusCode, responseStatusText,
-        requestStart.until(now(), ChronoUnit.MILLIS), request.getMethod(), request.getUri()));
+        millisOfResponseReceiving, request.getMethod(), request.getUri()));
 
       return proceedWithResponse(response);
     }
 
     @Override
     public void onThrowable(Throwable t) {
+      long millisOfResponseReceiving = requestStart.until(now(), ChronoUnit.MILLIS);
       Response response = TransportExceptionMapper.map(t, request.getUri());
       mdcCopy.doInContext(
           () -> log.warn(
               "ASYNC_HTTP_ERROR: client error after {} ms on {} {}: {}{}",
-              requestStart.until(now(), ChronoUnit.MILLIS),
+              millisOfResponseReceiving,
               request.getMethod(),
               request.getUri(),
               t.toString(),


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-73950


doInContext() вызывает n-нное количество методов, прежде чем выполнится Instant.now() внутри, так что теперь время ответа логироваться будет немного честнее.

есть еще небольшой лаг между созданием CompletionHandler и вызовом   httpClient.execute(), но там хз как вклиниться