### PR TITLE
HH-81931 Update dependencies versions for enforcer

### DIFF
--- a/client-maven-enforcer/pom.xml
+++ b/client-maven-enforcer/pom.xml
@@ -18,7 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.5.2</version>
                 <configuration>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
@@ -85,7 +85,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>5.0.4</asm.version>
+        <asm.version>6.2</asm.version>
     </properties>
 
     <prerequisites>


### PR DESCRIPTION
Update dependencies versions for enforcer. It is required for modules to be built with java 10. 