### PR TITLE
HH-101886 up kafka-clients lib in metrics module

### DIFF
--- a/client-metrics/pom.xml
+++ b/client-metrics/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.1.1</version>
+            <version>2.3.1</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-101886

конфликт версий kafka-clients в конечном сервисе spam-detetor (в nab 2.3.1, jclient-common - 2.1.1)
надо бы апнуть в jclient-common