### PR TITLE
HH-106137 add Accept header for errors

### DIFF
--- a/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
+++ b/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static ru.hh.jclient.common.HttpHeaderNames.X_HH_ACCEPT_ERRORS;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.Charset;
@@ -113,6 +114,7 @@ public class HttpClientTestBase {
     assertEquals(request1.getMethod(), request2.getMethod());
     ru.hh.jclient.common.HttpHeaders headers2 = request2.getHeaders();
     headers2.remove(ACCEPT);
+    headers2.remove(X_HH_ACCEPT_ERRORS);
     headers2.remove(HttpHeaderNames.X_OUTER_TIMEOUT_MS);
     assertEquals(request1.getHeaders(), headers2);
   }

--- a/client/src/main/java/ru/hh/jclient/common/EmptyResultProcessor.java
+++ b/client/src/main/java/ru/hh/jclient/common/EmptyResultProcessor.java
@@ -36,41 +36,56 @@ public class EmptyResultProcessor extends ResultProcessor<Void> {
 
   @Override
   public <E> EmptyOrErrorProcessor<E> orXmlError(JAXBContext context, Class<E> xmlClass) {
-    return new EmptyOrErrorProcessor<>(this, new XmlConverter<>(context, xmlClass));
+    XmlConverter<E> converter = new XmlConverter<>(context, xmlClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public <E> EmptyOrErrorProcessor<E> orJsonError(ObjectMapper mapper, Class<E> jsonClass) {
-    return new EmptyOrErrorProcessor<>(this, new JsonConverter<>(mapper, jsonClass));
+    JsonConverter<E> converter = new JsonConverter<>(mapper, jsonClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public <E> EmptyOrErrorProcessor<Collection<E>> orJsonCollectionError(ObjectMapper mapper, Class<E> jsonClass) {
-    return new EmptyOrErrorProcessor<>(this, new JsonCollectionConverter<>(mapper, jsonClass));
+    JsonCollectionConverter<E> converter = new JsonCollectionConverter<>(mapper, jsonClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public <K, V> EmptyOrErrorProcessor<Map<K, V>> orJsonMapError(ObjectMapper mapper, Class<K> jsonKeyClass, Class<V> jsonValueClass) {
-    return new EmptyOrErrorProcessor<>(this, new JsonMapConverter<>(mapper, jsonKeyClass, jsonValueClass));
+    JsonMapConverter<K, V> converter = new JsonMapConverter<>(mapper, jsonKeyClass, jsonValueClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public <E extends GeneratedMessageV3> EmptyOrErrorProcessor<E> orProtobufError(Class<E> protobufClass) {
-    return new EmptyOrErrorProcessor<>(this, new ProtobufConverter<>(protobufClass));
+    ProtobufConverter<E> converter = new ProtobufConverter<>(protobufClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public EmptyOrErrorProcessor<String> orPlainTextError() {
-    return new EmptyOrErrorProcessor<>(this, new PlainTextConverter());
+    PlainTextConverter converter = new PlainTextConverter();
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public EmptyOrErrorProcessor<String> orPlainTextError(Charset charset) {
-    return new EmptyOrErrorProcessor<>(this, new PlainTextConverter(charset));
+    PlainTextConverter converter = new PlainTextConverter(charset);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new EmptyOrErrorProcessor<>(this, converter);
   }
 
   @Override
   public <E> EmptyOrErrorProcessor<E> orError(TypeConverter<E> converter) {
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
     return new EmptyOrErrorProcessor<>(this, converter);
   }
 }

--- a/client/src/main/java/ru/hh/jclient/common/HttpClient.java
+++ b/client/src/main/java/ru/hh/jclient/common/HttpClient.java
@@ -53,6 +53,7 @@ public abstract class HttpClient {
   private Request request;
   private Optional<?> requestBodyEntity = Optional.empty();
   private Optional<Collection<MediaType>> expectedMediaTypes = Optional.empty();
+  private Optional<Collection<MediaType>> expectedMediaTypesForErrors = Optional.empty();
   private Integer maxRequestTimeoutTries;
   private boolean forceIdempotence = false;
 
@@ -373,6 +374,14 @@ public abstract class HttpClient {
 
   Optional<Collection<MediaType>> getExpectedMediaTypes() {
     return expectedMediaTypes;
+  }
+
+  Optional<Collection<MediaType>> getExpectedMediaTypesForErrors() {
+    return expectedMediaTypesForErrors;
+  }
+
+  void setExpectedMediaTypesForErrors(Optional<Collection<MediaType>> mediaTypes) {
+    expectedMediaTypesForErrors = mediaTypes;
   }
 
   List<RequestDebug> getDebugs() {

--- a/client/src/main/java/ru/hh/jclient/common/ResultProcessor.java
+++ b/client/src/main/java/ru/hh/jclient/common/ResultProcessor.java
@@ -115,7 +115,9 @@ public class ResultProcessor<T> {
    * @param xmlClass type of ERROR result
    */
   public <E> ResultOrErrorProcessor<T, E> orXmlError(JAXBContext context, Class<E> xmlClass) {
-    return new ResultOrErrorProcessor<>(this, new XmlConverter<>(context, xmlClass));
+    XmlConverter<E> converter = new XmlConverter<>(context, xmlClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -125,7 +127,9 @@ public class ResultProcessor<T> {
    * @param jsonClass type of ERROR result
    */
   public <E> ResultOrErrorProcessor<T, E> orJsonError(ObjectMapper mapper, Class<E> jsonClass) {
-    return new ResultOrErrorProcessor<>(this, new JsonConverter<>(mapper, jsonClass));
+    JsonConverter<E> converter = new JsonConverter<>(mapper, jsonClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -135,7 +139,9 @@ public class ResultProcessor<T> {
    * @param jsonClass type of ERROR result
    */
   public <E> ResultOrErrorProcessor<T, Collection<E>> orJsonCollectionError(ObjectMapper mapper, Class<E> jsonClass) {
-    return new ResultOrErrorProcessor<>(this, new JsonCollectionConverter<>(mapper, jsonClass));
+    JsonCollectionConverter<E> converter = new JsonCollectionConverter<>(mapper, jsonClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -146,7 +152,9 @@ public class ResultProcessor<T> {
    * @param jsonValueClass type of Value of the ERROR
    */
   public <K, V> ResultOrErrorProcessor<T, Map<K, V>> orJsonMapError(ObjectMapper mapper, Class<K> jsonKeyClass, Class<V> jsonValueClass) {
-    return new ResultOrErrorProcessor<>(this, new JsonMapConverter<>(mapper, jsonKeyClass, jsonValueClass));
+    JsonMapConverter<K, V> converter = new JsonMapConverter<>(mapper, jsonKeyClass, jsonValueClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -155,14 +163,18 @@ public class ResultProcessor<T> {
    * @param protobufClass type of ERROR result
    */
   public <E extends GeneratedMessageV3> ResultOrErrorProcessor<T, E> orProtobufError(Class<E> protobufClass) {
-    return new ResultOrErrorProcessor<>(this, new ProtobufConverter<>(protobufClass));
+    ProtobufConverter<E> converter = new ProtobufConverter<>(protobufClass);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
    * Specifies that the type of ERROR result must be plain text with {@link PlainTextConverter#DEFAULT default} encoding.
    */
   public ResultOrErrorProcessor<T, String> orPlainTextError() {
-    return new ResultOrErrorProcessor<>(this, new PlainTextConverter());
+    PlainTextConverter converter = new PlainTextConverter();
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -171,7 +183,9 @@ public class ResultProcessor<T> {
    * @param charset used to decode response
    */
   public ResultOrErrorProcessor<T, String> orPlainTextError(Charset charset) {
-    return new ResultOrErrorProcessor<>(this, new PlainTextConverter(charset));
+    PlainTextConverter converter = new PlainTextConverter(charset);
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
+    return new ResultOrErrorProcessor<>(this, converter);
   }
 
   /**
@@ -180,6 +194,7 @@ public class ResultProcessor<T> {
    * @param converter used to convert response to expected ERROR result
    */
   public <E> ResultOrErrorProcessor<T, E> orError(TypeConverter<E> converter) {
+    getHttpClient().setExpectedMediaTypesForErrors(converter.getSupportedMediaTypes());
     return new ResultOrErrorProcessor<>(this, converter);
   }
 }

--- a/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
+++ b/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
@@ -12,4 +12,5 @@ public class HttpHeaderNames {
   public static final String X_LOAD_TESTING = "X-Load-Testing";
   public static final String X_SOURCE = "X-Source";
   public static final String X_OUTER_TIMEOUT_MS = "X-Outer-Timeout-Ms";
+  public static final String X_HH_ACCEPT_ERRORS = "X-HH-AcceptErrors";
 }


### PR DESCRIPTION
при использовании методов orJsonError, orXmlError и т.п. теперь будет добавляться дополнительный хэдер, сообщающай о ожидаемом формате сообщения в случае неуспешного статуса. 