### PR TITLE
HH-110560 don't pass debug header if we can't parse debug response

### DIFF
--- a/client-errors/pom.xml
+++ b/client-errors/pom.xml
@@ -52,19 +52,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <localCheckout>true</localCheckout>

--- a/client-maven-enforcer/pom.xml
+++ b/client-maven-enforcer/pom.xml
@@ -38,18 +38,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/client-metrics/pom.xml
+++ b/client-metrics/pom.xml
@@ -59,19 +59,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <localCheckout>true</localCheckout>

--- a/client-testbase/pom.xml
+++ b/client-testbase/pom.xml
@@ -41,19 +41,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <localCheckout>true</localCheckout>

--- a/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
+++ b/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
@@ -36,12 +36,14 @@ import com.google.common.net.MediaType;
 
 public class HttpClientTestBase {
 
-  static AsyncHttpClientConfig httpClientConfig = new DefaultAsyncHttpClientConfig.Builder().build();
-  public static HttpClientFactory http;
-  static HttpClientContext httpClientContext;
-  static TestRequestDebug debug = new TestRequestDebug(true);
-  static List<Supplier<RequestDebug>> debugs = List.of(() -> debug);
-  static List<HttpClientEventListener> eventListeners = new ArrayList<>();
+  private static final AsyncHttpClientConfig defaultHttpClientConfig = new DefaultAsyncHttpClientConfig.Builder().build();
+
+  protected AsyncHttpClientConfig httpClientConfig = defaultHttpClientConfig;
+  protected HttpClientFactory http;
+  protected HttpClientContext httpClientContext;
+  protected TestRequestDebug debug = new TestRequestDebug(true);
+  protected List<Supplier<RequestDebug>> debugs = List.of(() -> debug);
+  protected List<HttpClientEventListener> eventListeners = new ArrayList<>();
 
   public HttpClientTestBase withEmptyContext() {
     httpClientContext = new HttpClientContext(Collections.emptyMap(), Collections.emptyMap(), debugs);
@@ -69,6 +71,10 @@ public class HttpClientTestBase {
 
   public Supplier<Request> okRequest(byte[] data, MediaType contentType) {
     return request(data, contentType, 200);
+  }
+
+  public Supplier<Request> noContentRequest() {
+    return request(null, 204);
   }
 
   public Supplier<Request> request(byte[] data, MediaType contentType, int status) {

--- a/client-testbase/src/main/java/ru/hh/jclient/common/TestRequestDebug.java
+++ b/client-testbase/src/main/java/ru/hh/jclient/common/TestRequestDebug.java
@@ -13,12 +13,19 @@ public class TestRequestDebug implements RequestDebug {
 
   private final List<Call> calls = new ArrayList<>();
   private final boolean recordCalls;
+  private final boolean canUnwrapDebugResponse;
+
   public TestRequestDebug() {
     this(false);
   }
 
   public TestRequestDebug(boolean recordCalls) {
+    this(recordCalls, false);
+  }
+
+  public TestRequestDebug(boolean recordCalls, boolean canUnwrapDebugResponse) {
     this.recordCalls = recordCalls;
+    this.canUnwrapDebugResponse = canUnwrapDebugResponse;
   }
 
   public List<Call> getCalls() {
@@ -49,6 +56,11 @@ public class TestRequestDebug implements RequestDebug {
   public ru.hh.jclient.common.Response onResponse(ru.hh.jclient.common.Response response) {
     record(Call.RESPONSE);
     return response;
+  }
+
+  @Override
+  public boolean canUnwrapDebugResponse() {
+    return canUnwrapDebugResponse;
   }
 
   @Override

--- a/client-tests/pom.xml
+++ b/client-tests/pom.xml
@@ -84,4 +84,27 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <skipSource>true</skipSource>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/client-tests/src/test/java/ru/hh/jclient/common/BalancingClientTestBase.java
+++ b/client-tests/src/test/java/ru/hh/jclient/common/BalancingClientTestBase.java
@@ -52,7 +52,6 @@ abstract class BalancingClientTestBase extends HttpClientTestBase {
     withEmptyContext();
     httpClient = mock(AsyncHttpClient.class);
     when(httpClient.getConfig()).thenReturn(httpClientConfig);
-    debug.reset();
   }
 
   @Test

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -13,19 +13,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <localCheckout>true</localCheckout>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -115,19 +115,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <localCheckout>true</localCheckout>

--- a/client/src/main/java/ru/hh/jclient/common/RequestDebug.java
+++ b/client/src/main/java/ru/hh/jclient/common/RequestDebug.java
@@ -23,6 +23,11 @@ public interface RequestDebug {
     }
 
     @Override
+    public boolean canUnwrapDebugResponse() {
+      return false;
+    }
+
+    @Override
     public void onResponseConverted(Optional<?> result) {
     }
 
@@ -54,6 +59,14 @@ public interface RequestDebug {
    * purposes.
    */
   Response onResponse(Response response);
+
+  /**
+   * Tells if {@link #onResponse(Response)} can extract actual response from a debug response envelope
+   * (see {@link HttpHeaderNames#X_HH_DEBUG})
+   */
+  default boolean canUnwrapDebugResponse() {
+    return false;
+  }
 
   /**
    * Called once response is successfully converted.

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,17 @@
                     <excludes>**/ru/hh/jclient/common/model/ProtobufTest.java</excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-110560

Добавил новый `default`-метод `canUnwrapDebugResponse()` в интерфейс `RequestDebug`. Если в текущем контексте нет ни одного `RequestDebug`-а, для которого метод возвращает `true`, то debug в исходящие запросы не прокидываем, т.к. распарсить debug-ответ мы не сможем.

Для jdebug сделано в https://github.com/hhru/jdebug/pull/24