### PR TITLE
HH-140552 chain config actions in createCustomizedCopy()

### DIFF
--- a/balancing/src/main/java/ru/hh/jclient/common/balancing/BalancingRequestStrategy.java
+++ b/balancing/src/main/java/ru/hh/jclient/common/balancing/BalancingRequestStrategy.java
@@ -40,6 +40,7 @@ public class BalancingRequestStrategy implements RequestStrategy<RequestBalancer
 
   @Override
   public BalancingRequestStrategy createCustomizedCopy(UnaryOperator<RequestBalancerBuilder> configAction) {
-    return new BalancingRequestStrategy(this.upstreamManager, upstreamService, upstreamConfigService, configAction);
+    UnaryOperator<RequestBalancerBuilder> chainedConfigAction = this.configAction.andThen(configAction)::apply;
+    return new BalancingRequestStrategy(upstreamManager, upstreamService, upstreamConfigService, chainedConfigAction);
   }
 }

--- a/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
+++ b/client-testbase/src/main/java/ru/hh/jclient/common/HttpClientTestBase.java
@@ -197,7 +197,7 @@ public class HttpClientTestBase {
     return new HttpClientFactory(httpClient, singleton("http://localhost"),
         new SingletonStorage<>(() -> httpClientContext),
         Runnable::run,
-        new DefaultRequestStrategy().createCustomizedCopy(engimeBuilder -> engimeBuilder.withTimeoutMultiplier(timeoutMultiplier)),
+        new DefaultRequestStrategy().createCustomizedCopy(engineBuilder -> engineBuilder.withTimeoutMultiplier(timeoutMultiplier)),
         eventListeners
     );
   }

--- a/client-tests/src/test/java/ru/hh/jclient/common/BalancingClientTestBase.java
+++ b/client-tests/src/test/java/ru/hh/jclient/common/BalancingClientTestBase.java
@@ -401,8 +401,13 @@ abstract class BalancingClientTestBase extends HttpClientTestBase {
   static void assertHostEquals(Request request, String host) {
     assertEquals(host, request.getUri().getHost());
   }
+
   static void assertRequestTimeoutEquals(Request request, long timeoutMs) {
     assertEquals((int) timeoutMs, request.getRequestTimeout());
+  }
+
+  static void assertRequestTimeoutEquals(Request request, double timeoutMs) {
+    assertRequestTimeoutEquals(request, (long) timeoutMs);
   }
 
   private HttpClientFactory createHttpClientFactory(AsyncHttpClient httpClient, String datacenter, List<String> upstreamList,

--- a/client-tests/src/test/java/ru/hh/jclient/common/bench/BalancingPerformanceBenchmark.java
+++ b/client-tests/src/test/java/ru/hh/jclient/common/bench/BalancingPerformanceBenchmark.java
@@ -151,7 +151,7 @@ public class BalancingPerformanceBenchmark {
 
     @Override
     public RequestStrategy<RequestBalancerBuilder> createCustomizedCopy(UnaryOperator<RequestBalancerBuilder> configAction) {
-      return new CustomStrategy(upstreamManager, configAction);
+      return new CustomStrategy(upstreamManager, this.configAction.andThen(configAction)::apply);
     }
   }
 

--- a/client-tests/src/test/java/ru/hh/jclient/common/bench/CustomizationBenchmark.java
+++ b/client-tests/src/test/java/ru/hh/jclient/common/bench/CustomizationBenchmark.java
@@ -135,7 +135,7 @@ public class CustomizationBenchmark {
 
     @Override
     public RequestStrategy<RequestBalancerBuilder> createCustomizedCopy(UnaryOperator<RequestBalancerBuilder> configAction) {
-      return new CustomStrategy(upstreamManager, configAction);
+      return new CustomStrategy(upstreamManager, this.configAction.andThen(configAction)::apply);
     }
   }
 }

--- a/client/src/main/java/ru/hh/jclient/common/DefaultRequestStrategy.java
+++ b/client/src/main/java/ru/hh/jclient/common/DefaultRequestStrategy.java
@@ -1,7 +1,7 @@
 package ru.hh.jclient.common;
 
-import static java.util.Optional.ofNullable;
 import java.util.function.UnaryOperator;
+import static java.util.function.UnaryOperator.identity;
 
 public class DefaultRequestStrategy implements RequestStrategy<DefaultEngineBuilder> {
   private final UnaryOperator<DefaultEngineBuilder> configAction;
@@ -11,16 +11,16 @@ public class DefaultRequestStrategy implements RequestStrategy<DefaultEngineBuil
   }
 
   public DefaultRequestStrategy() {
-    this(null);
+    this(identity());
   }
 
   @Override
   public DefaultEngineBuilder createRequestEngineBuilder(HttpClient client) {
-    return ofNullable(configAction).map(action -> action.apply(new DefaultEngineBuilder(client))).orElseGet(() -> new DefaultEngineBuilder(client));
+    return configAction.apply(new DefaultEngineBuilder(client));
   }
 
   @Override
   public RequestStrategy<DefaultEngineBuilder> createCustomizedCopy(UnaryOperator<DefaultEngineBuilder> configAction) {
-    return new DefaultRequestStrategy(configAction);
+    return new DefaultRequestStrategy(this.configAction.andThen(configAction)::apply);
   }
 }


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-140552

Сделал так, что действие, переданное в `createCustomizedCopy()`, не заменяет предыдущее, а выполняется после него.
Нужно, чтобы код вида
```java
httpClientFactory.createCustomizedCopy(requestEngineBuilder -> requestEngineBuilder.withProfile("profile"));
```
не перетирал предыдущую конфигурацию `RequestEngineBuilder`, в частности, `timeoutMultiplier` (см. [HttpClientFactoryBuilder.java#L194](https://github.com/hhru/jclient-common/blob/HH-140552/client/src/main/java/ru/hh/jclient/common/HttpClientFactoryBuilder.java#L194)).
