### PR TITLE
Hh 197107 ContentType getters & extra headers

### DIFF
--- a/client/src/main/java/ru/hh/jclient/common/util/ContentType.java
+++ b/client/src/main/java/ru/hh/jclient/common/util/ContentType.java
@@ -3,6 +3,8 @@ package ru.hh.jclient.common.util;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class ContentType {
 
@@ -29,6 +31,7 @@ public class ContentType {
 
   private final String type;
   private final String subtype;
+  @Nullable
   private final String charset;
 
   public ContentType(String contentType) {
@@ -51,6 +54,18 @@ public class ContentType {
     else {
       charset = null;
     }
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public String getSubtype() {
+    return subtype;
+  }
+
+  public Optional<String> getCharset() {
+    return Optional.ofNullable(charset);
   }
 
   public boolean allows(ContentType contentType) {

--- a/client/src/main/java/ru/hh/jclient/common/util/ContentType.java
+++ b/client/src/main/java/ru/hh/jclient/common/util/ContentType.java
@@ -27,8 +27,8 @@ public class ContentType {
   public static final String APPLICATION_FORM_DATA = "application/x-www-form-urlencoded";
   public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 
-  private final String type1;
-  private final String type2;
+  private final String type;
+  private final String subtype;
   private final String charset;
 
   public ContentType(String contentType) {
@@ -39,13 +39,13 @@ public class ContentType {
       throw new IllegalArgumentException("Wrong content type format");
     }
 
-    String[] typeAndParams = contentType.trim().toLowerCase().split(";");
-    String[] type = typeAndParams[0].split("/");
-    type1 = type[0].trim();
-    type2 = type[1].trim();
+    String[] splittedContentType = contentType.trim().toLowerCase().split(";");
+    String[] typeAndSubtype = splittedContentType[0].split("/");
+    type = typeAndSubtype[0].trim();
+    subtype = typeAndSubtype[1].trim();
 
-    if (typeAndParams.length > 1) {
-      String[] params = typeAndParams[1].trim().split(",");
+    if (splittedContentType.length > 1) {
+      String[] params = splittedContentType[1].trim().split(",");
       charset = Arrays.stream(params).filter(p -> p.contains("charset")).findAny().map(p -> p.split("=")[1].trim()).orElse(null);
     }
     else {
@@ -54,10 +54,10 @@ public class ContentType {
   }
 
   public boolean allows(ContentType contentType) {
-    if (!type1.equals(WILDCARD) && !type1.equals(contentType.type1)) {
+    if (!type.equals(WILDCARD) && !type.equals(contentType.type)) {
       return false;
     }
-    if (!type2.equals(WILDCARD) && !type2.equals(contentType.type2)) {
+    if (!subtype.equals(WILDCARD) && !subtype.equals(contentType.subtype)) {
       return false;
     }
     return charset == null || Objects.equals(charset, contentType.charset);

--- a/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
+++ b/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
@@ -6,7 +6,12 @@ public class HttpHeaderNames {
 
   public static final String ACCEPT = "Accept";
   public static final String AUTHORIZATION = "Authorization";
+  public static final String CACHE_CONTROL = "Cache-Control";
+  public static final String CONTENT_LENGTH = "Content-Length";
   public static final String CONTENT_TYPE = "Content-Type";
+  public static final String COOKIE = "Cookie";
+  public static final String EXPIRES = "Expires";
+  public static final String PRAGMA = "Pragma";
   public static final String FRONTIK_DEBUG_AUTH = "Frontik-Debug-Auth";
   public static final String HH_PROTO_SESSION = "Hh-Proto-Session";
   public static final String TMS_PROTO_SESSION = "X-TMS-Session-Proto";

--- a/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
+++ b/jclient-common-api/src/main/java/ru/hh/jclient/common/HttpHeaderNames.java
@@ -4,20 +4,19 @@ public class HttpHeaderNames {
   private HttpHeaderNames() {
   }
 
-  public static final String X_HH_DEBUG = "X-Hh-Debug";
-  public static final String FRONTIK_DEBUG_AUTH = "Frontik-Debug-Auth";
-  public static final String HH_PROTO_SESSION = "Hh-Proto-Session";
-  public static final String TMS_PROTO_SESSION = "X-TMS-Session-Proto";
-  public static final String X_REQUEST_ID = "X-Request-Id";
-  public static final String X_REAL_IP = "X-Real-IP";
-  public static final String X_LOAD_TESTING = "X-Load-Testing";
-  public static final String X_SOURCE = "X-Source";
-  public static final String X_OUTER_TIMEOUT_MS = "X-Outer-Timeout-Ms";
-  public static final String X_HH_ACCEPT_ERRORS = "X-HH-AcceptErrors";
-  public static final String USER_AGENT = "User-Agent";
   public static final String ACCEPT = "Accept";
   public static final String AUTHORIZATION = "Authorization";
   public static final String CONTENT_TYPE = "Content-Type";
+  public static final String FRONTIK_DEBUG_AUTH = "Frontik-Debug-Auth";
+  public static final String HH_PROTO_SESSION = "Hh-Proto-Session";
+  public static final String TMS_PROTO_SESSION = "X-TMS-Session-Proto";
+  public static final String USER_AGENT = "User-Agent";
+  public static final String X_HH_ACCEPT_ERRORS = "X-HH-AcceptErrors";
+  public static final String X_HH_DEBUG = "X-Hh-Debug";
   public static final String X_HH_PROFESSIONAL_ROLES_MODE = "X-HH-ProfessionalRolesMode";
-
+  public static final String X_LOAD_TESTING = "X-Load-Testing";
+  public static final String X_OUTER_TIMEOUT_MS = "X-Outer-Timeout-Ms";
+  public static final String X_REAL_IP = "X-Real-IP";
+  public static final String X_REQUEST_ID = "X-Request-Id";
+  public static final String X_SOURCE = "X-Source";
 }


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-197107

version changes: MINOR
compatible: true
description:
- Add getters for ContentType  
- add extra constants in HttpHeaderNames: Cache-Control, Content-Length, Cookie, Expires, Pragma