### PR TITLE
HH-212924 change initial live percent behaviour in DowntimeDetector

### DIFF
--- a/balancing/src/main/java/ru/hh/jclient/common/balancing/DowntimeDetector.java
+++ b/balancing/src/main/java/ru/hh/jclient/common/balancing/DowntimeDetector.java
@@ -7,7 +7,7 @@ public class DowntimeDetector {
   private final float errorsThreshold;
 
   private volatile int errorsCount;
-  private int current;
+  private int current = 0;
 
   public DowntimeDetector(int n) {
     this(n, ERRORS_THRESHOLD, 100);
@@ -31,13 +31,11 @@ public class DowntimeDetector {
     int initialErrorsCount = n * (100 - initialLivePercent) / 100;
     if (initialErrorsCount > 0) {
       this.errorsCount = initialErrorsCount;
-      this.current = initialErrorsCount;
       for (int i = 0; i < initialErrorsCount; i++) {
         errors[i] = 1;
       }
     } else {
       this.errorsCount = 0;
-      this.current = 0;
     }
   }
 


### PR DESCRIPTION
> [!IMPORTANT] 
> Добавь в описание PR changelog в формате:

- [ ] **version change** PATCH
- [ ] **description**: Change the behavior of the initial_live_percent setting in such a way that the effect lasts for a shorter period of time. In the past, the effect's behavior was noticeable for the entire window size (n), but now it will only be noticeable for the duration of the first requests that fall within the window of failed requests
- [ ] **requires_changes_in_hh** false
