### PR TITLE
HH-227013 disable netty retries by default

### DIFF
--- a/.hh-release.yaml
+++ b/.hh-release.yaml
@@ -1,12 +1,7 @@
 version: 3.12.15
 build_image: registry.pyn.ru/openjdk17-building:2024.05.01
-docker_files:
-  none: none
 build_method: mvn_build
 deploy_method: mvn_deploy
 update_method: mvn_update
-wiki_links:
-  - https://wiki.hh.ru/pages/viewpage.action?pageId=322903998
-  - https://github.com/hhru/jclient-common/releases
 type: library
 changelog: true

--- a/client-errors/pom.xml
+++ b/client-errors/pom.xml
@@ -47,18 +47,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
-
 </project>

--- a/client-maven-enforcer/pom.xml
+++ b/client-maven-enforcer/pom.xml
@@ -13,22 +13,24 @@
     <name>jclient-common maven enforcer plugin</name>
     <description>Enforce @JResource annotation on jclient methods</description>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.version>3.8.6</maven.version>
+        <maven-plugin-tools.version>3.8.2</maven-plugin-tools.version>
+        <asm.version>9.3</asm.version>
+    </properties>
+
+    <prerequisites>
+        <maven>${maven.version}</maven>
+    </prerequisites>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                </configuration>
+                <version>${maven-plugin-tools.version}</version>
                 <executions>
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
                     <!-- if you want to generate help goal -->
                     <execution>
                         <id>help-goal</id>
@@ -70,32 +72,27 @@
         </pluginManagement>
     </build>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>9.3</asm.version>
-    </properties>
-
-    <prerequisites>
-        <maven>3.0.5</maven>
-    </prerequisites>
-
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.8.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugin-tools</groupId>
-            <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.6.4</version>
+            <version>${maven.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
-            <artifactId>maven-project</artifactId>
-            <version>2.2.1</version>
+            <artifactId>maven-core</artifactId>
+            <version>${maven.version}</version>
+            <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${maven-plugin-tools.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>

--- a/client-metrics/pom.xml
+++ b/client-metrics/pom.xml
@@ -38,16 +38,4 @@
 
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/client-testbase/pom.xml
+++ b/client-testbase/pom.xml
@@ -28,30 +28,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
         </dependency>
-
-        <!-- Logging for tests -->
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-        </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 
 </project>

--- a/client-tests/pom.xml
+++ b/client-tests/pom.xml
@@ -20,7 +20,6 @@
             <artifactId>value</artifactId>
             <version>${immutables.version}</version>
             <classifier>annotations</classifier>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -31,22 +30,29 @@
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-generator-annprocess</artifactId>
             <version>${jmh.version}</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>ru.hh.jclient-common</groupId>
             <artifactId>jclient-common-testbase</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ru.hh.jclient-common</groupId>
             <artifactId>jclient-balancing</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
+        </dependency>
+
+        <!-- Logging for tests -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
         </dependency>
     </dependencies>
 

--- a/client-utils/pom.xml
+++ b/client-utils/pom.xml
@@ -9,16 +9,4 @@
     <artifactId>jclient-common-utils</artifactId>
     <packaging>jar</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -97,16 +97,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <configuration>
-                    <localCheckout>true</localCheckout>
-                    <pushChanges>false</pushChanges>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/client/src/main/java/ru/hh/jclient/common/HttpClientFactoryBuilder.java
+++ b/client/src/main/java/ru/hh/jclient/common/HttpClientFactoryBuilder.java
@@ -33,13 +33,14 @@ public class HttpClientFactoryBuilder {
   private final List<HttpClientEventListener> eventListeners;
 
   public HttpClientFactoryBuilder(Storage<HttpClientContext> contextSupplier, List<HttpClientEventListener> eventListeners) {
-    this.configBuilder = new DefaultAsyncHttpClientConfig.Builder();
+    this.configBuilder = defaultConfigBuilder();
     this.contextSupplier = contextSupplier;
     this.eventListeners = new ArrayList<>(eventListeners);
   }
 
   private HttpClientFactoryBuilder(HttpClientFactoryBuilder prototype) {
-    this(new DefaultAsyncHttpClientConfig.Builder(prototype.configBuilder.build()),
+    this(
+        new DefaultAsyncHttpClientConfig.Builder(prototype.configBuilder.build()),
         prototype.requestStrategy, prototype.callbackExecutor,
         prototype.contextSupplier,
         ofNullable(prototype.customHostsWithSession).map(Set::copyOf).orElse(null),
@@ -52,7 +53,7 @@ public class HttpClientFactoryBuilder {
 
   private HttpClientFactoryBuilder(
       DefaultAsyncHttpClientConfig.Builder configBuilder,
-      RequestStrategy<? extends RequestEngineBuilder> requestStrategy,
+      RequestStrategy<? extends RequestEngineBuilder<?>> requestStrategy,
       Executor callbackExecutor,
       Storage<HttpClientContext> contextSupplier,
       Set<String> customHostsWithSession,
@@ -70,6 +71,11 @@ public class HttpClientFactoryBuilder {
     this.balancingRequestsLogLevel = balancingRequestsLogLevel;
     this.metricsConsumer = metricsConsumer;
     this.eventListeners = eventListeners;
+  }
+
+  private static DefaultAsyncHttpClientConfig.Builder defaultConfigBuilder() {
+    return new DefaultAsyncHttpClientConfig.Builder()
+        .setMaxRequestRetry(0);
   }
 
   public HttpClientFactoryBuilder withProperties(Properties properties) {
@@ -136,7 +142,7 @@ public class HttpClientFactoryBuilder {
     return target;
   }
 
-  public HttpClientFactoryBuilder withRequestStrategy(RequestStrategy<? extends RequestEngineBuilder> requestStrategy) {
+  public HttpClientFactoryBuilder withRequestStrategy(RequestStrategy<? extends RequestEngineBuilder<?>> requestStrategy) {
     var target = getCopy();
     target.requestStrategy = requestStrategy;
     return target;
@@ -268,7 +274,8 @@ public class HttpClientFactoryBuilder {
   }
 
   public static final class ConfigKeys {
-    private ConfigKeys() {}
+    private ConfigKeys() {
+    }
 
     public static final String USER_AGENT = "userAgent";
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,17 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <configuration>
+                        <tagNameFormat>@{project.version}</tagNameFormat>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <module>client-errors</module>
         <module>client-testbase</module>
         <module>client-tests</module>
-        <module>client-utils</module>		
+        <module>client-utils</module>
         <module>client-maven-enforcer</module>
         <module>client-metrics</module>
         <module>jclient-common-api</module>
@@ -99,17 +99,6 @@
                 <configuration>
                     <excludes>**/ru/hh/jclient/common/model/ProtobufTest.java</excludes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <!-- need only for test purposes -->
             <plugin>


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-227013

Отключил по умолчанию ретраи netty.
И почистил помники от лишнего.

- [x] **version change** <!--[MAJOR|MINOR|PATCH]-->: MAJOR
- [x] **description**: Внутренние ретраи netty теперь по умолчанию отключены (можно включить настройкой `jclient.maxRequestRetries=` или вызовом `HttpClientFactoryBuilder.withMaxRequestRetries()`, но не рекомендуется, т.к. эти ретраи не знают про балансировку).
   Для плагина `jclient-common-maven-enforcer` минимальная версия maven поднята до 3.8.6.
- [x] **requires_changes_in_hh** <!-- [true|false] -->: true
- [x] **instructions** <!-- [if requires_changes_in_hh]-->: Если у вас подключен плагин `jclient-common-maven-enforcer`, то надо убедиться, что для сборки проекта используется maven 3.8.6 или выше.
